### PR TITLE
追加:出退勤履歴一覧表示機能

### DIFF
--- a/app/Http/Controllers/RecordController.php
+++ b/app/Http/Controllers/RecordController.php
@@ -9,6 +9,7 @@ class RecordController extends Controller
 {
     public function index(Record $record)
     {
-        return $record->get();
+        return view('records.index')->with(['records' => $record->getPaginateByLimit()]);
     }
+    
 }

--- a/app/Models/Record.php
+++ b/app/Models/Record.php
@@ -8,4 +8,10 @@ use Illuminate\Database\Eloquent\Model;
 class Record extends Model
 {
     use HasFactory;
+    
+    public function getPaginateByLimit(int $limit_count = 10)
+    {
+        // updated_atで降順に並べたあと、limitで件数制限をかける
+        return $this->orderBy('updated_at', 'DESC')->paginate($limit_count);
+    }
 }

--- a/resources/views/records/index.blade.php
+++ b/resources/views/records/index.blade.php
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_','-',app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <title>Record</title>
+        <!-- Fonts -->
+        <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+    </head>
+    <body>
+        <h1>Records</h1>
+        <div class='records'>
+            <div class='record'>
+            <table>
+                <tr>
+                    <td>id</td>
+                    <td>date</td>
+                    <td>time_in</td>
+                    <td>time_out</td>
+                    <td>break_in</td>
+                    <td>break_out</td>
+                    <td>remarks</td>
+                </tr>
+            @foreach($records as $record)
+                <tr>
+                    <td>{{ $record->id }} </td>
+                    <td>{{ $record->date }} </td>
+                    <td>{{ $record->time_in }} </td>
+                    <td>{{ $record->time_out }} </td>
+                    <td>{{ $record->break_in }} </td>
+                    <td>{{ $record->break_out }} </td>
+                    <td>{{ $record->remarks }} </td>
+                </tr>
+            @endforeach
+            </div>
+        </div>
+        <div class='paginate'>
+            {{ $records->links() }}
+        </div>
+    </body>

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,7 +14,7 @@ use App\Http\Controllers\RecordController;
 |
 */
 
-Route::get('/', [PostController::class, 'index']);
+Route::get('/posts', [PostController::class, 'index']);
 Route::get('/posts/create', [PostController::class, 'create']);
 Route::get('/posts/{post}',[PostController::class,'show']);
 // '/posts/{対象データのID}'にGetリクエストが来たら、PostControllerのshowメソッドを実行する
@@ -28,3 +28,4 @@ Route::delete('/posts/{post}', [PostController::class, 'delete']);
 
 
 Route::get('/records', [RecordController::class, 'index']);
+Route::get('/', [RecordController::class, 'index']);


### PR DESCRIPTION
RecordController.php
・index関数をgetPaginateByLimitで代入された$postをpostsに入れて返すように
Record.php
・取得件数制限を設定
records/index.blade.php
・作成
・テーブルでrecordsテーブル内の要素を表示するように
route.php
・起動後https://~~~/にアクセスするとrecords/index.blade.phpを表示するようにルーティングを追加
・/postsでpostのindex関数を呼ぶように変更